### PR TITLE
Support the comma delimited lists for a tag

### DIFF
--- a/test/feature-finder-spec.js
+++ b/test/feature-finder-spec.js
@@ -12,42 +12,48 @@ describe('Feature Finder', function(){
   it('should find all scenarios with default options', function () {
     var opts = options.default;
     var expectedResult = results.default;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 
   it('should find only tagged scenarios when passed a tag', function () {
     var opts = options.tagged;
     var expectedResult = results.tagged;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 
   it('should not find scenario when using negated tag', function () {
     var opts = options.negatedTag;
     var expectedResult = results.negatedTag;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 
   it('should support multiple tags', function () {
     var opts = options.multipleTags;
     var expectedResult = results.multipleTags;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 
-  it('should support mixed tag', function () {
+  it('should support mixed tags', function () {
     var opts = options.mixedTags;
     var expectedResult = results.mixedTags;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
+  });
+
+  it('should support "or" tags', function () {
+    var opts = options.orOperatorTags;
+    var expectedResult = results.orOperatorTags;
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 
   it('should support direct feature paths', function () {
     var opts = options.featurePath;
     var expectedResult = results.featurePath;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 
   it('should support multiple paths', function () {
     var opts = options.multiplePaths;
     var expectedResult = results.multiplePaths;
-    featureFinder(opts).should.eventually.deep.equal(expectedResult);
+    return featureFinder(opts).should.eventually.deep.equal(expectedResult);
   });
 });

--- a/test/fixtures/options.json
+++ b/test/fixtures/options.json
@@ -37,7 +37,16 @@
   },
   "mixedTags": {
     "paths": ["test/features"],
-    "tags": ["@UnitTest", "~@Ignore"],
+    "tags": ["@Secondary", "~@Ignore"],
+    "requires": [],
+    "cucumberPath": "../../node_modules/cucumber",
+    "workers": 1,
+    "logDir": ".unit-test-tmp",
+    "silentSummary": true
+  },
+  "orOperatorTags": {
+    "paths": ["test/features"],
+    "tags": ["@Secondary,@UnitTest"],
     "requires": [],
     "cucumberPath": "../../node_modules/cucumber",
     "workers": 1,

--- a/test/results/feature-finder.json
+++ b/test/results/feature-finder.json
@@ -55,6 +55,16 @@
     {
       "featureFile": "test/features/sample.feature",
       "scenarioLine": 7
+    }
+  ],
+  "orOperatorTags": [
+    {
+      "featureFile": "test/features/sample.feature",
+      "scenarioLine": 7
+    },
+    {
+      "featureFile": "test/features/sample.feature",
+      "scenarioLine": 11
     },
     {
       "featureFile": "test/features/sample2.feature",

--- a/test/test-handler-spec.js
+++ b/test/test-handler-spec.js
@@ -15,8 +15,8 @@ describe('Test Handler', function() {
 
     let cukeRunner = new TestHandler(opts);
 
-    cukeRunner.run().then(() => {
-      cukeRunner.workers.should.be.empty;
+    return cukeRunner.run().then(() => {
+      return cukeRunner.workers.should.be.empty;
     })
   });
 
@@ -47,7 +47,7 @@ describe('Test Handler', function() {
 
     let cukeRunner = new TestHandler(opts);
     return cukeRunner.run().then((results) => {
-      results.should.have.property('outputHandler');
+      return results.should.have.property('outputHandler');
     });
   });
 
@@ -57,7 +57,7 @@ describe('Test Handler', function() {
 
     let cukeRunner = new TestHandler(opts);
     return cukeRunner.run().then((results) => {
-      results.outputHandler.getSummaryOutput().should.not.be.empty;
+      return results.outputHandler.getSummaryOutput().should.not.be.empty;
     });
   });
 


### PR DESCRIPTION
Logic change to support comma delimited tags as defined by Cucumber (i.e. `-t @Run1,@Run2' should return anything tagged @Run1 OR @Run2, not necessarily both)
