### PR TITLE
Single worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "babel-register": "^6.5.2",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "mocha": "^2.4.5"
   },
   "author": "Ian Fleming <ian@midnite.io>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-cuke",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Forked Cucumber-js for parallel testing",
   "main": "distribution/main.js",
   "scripts": {

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -60,9 +60,10 @@ export default class TestHandler {
   createWorker(scenario) {
     let workerModulePath = path.join(__dirname, 'worker');
     let workerEnv = _.merge(
+      process.env,
+      this.options.workerEnvVars,
       scenario,
-      { testOptions: JSON.stringify(this.options) },
-      this.options.workerEnvVars
+      {testOptions: JSON.stringify(this.options)}
     );
     let worker = fork(workerModulePath, [], {
       env: workerEnv,

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -21,9 +21,10 @@ testOptions.requires.forEach(function(arg) {
 let startTime = new Date();
 
 try {
-  cucumber(args).run(function() {
+  cucumber(args).run(function(isSuccessful) {
+    let exitCode = (isSuccessful) ? 0 : 1;
     process.send({
-      exitCode: 0,
+      exitCode: exitCode,
       resultFile: logFile,
       duration: new Date() - startTime
     });


### PR DESCRIPTION
If workers number passed is 1, default to standard cucumber output to allow realtime results and be debuggable. This also corrects a few instances of exitCode misassignment
