### PR TITLE
Support debug logging from within silenced workers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -209,7 +209,11 @@
 
     // Require one true brace style
     // Reasons: readability, stylistic
-    "brace-style": [2, "1tbs", { "allowSingleLine": true }]
+    "brace-style": [2, "1tbs", { "allowSingleLine": true }],
+
+    // Require semicolon at EOL
+    // Reasons: maintainability
+    "semi": [2, "always"]
   }
 
 }

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
-import program from 'commander'
-
-import pkg from '../../package.json'
+import program from 'commander';
+import pkg from '../../package.json';
 
 function collect(val, collection) {
   collection.push(val);
@@ -23,7 +22,7 @@ program
   .option('-s, --silentsummary', 'Silences summary output so it can be handled via the returned promise')
   .option('-v, --verbose', 'Adds verbose output to console')
   .option('-i, --inlinestream',
-    'Inlines stream in real time in addition to multi-cuke output\n' +
+    'Inlines stream in real time in addition to multi-cuke output. ' +
     '*Note* This adds complexity to the logs that are hard to decipher, but included if needed for debugging'
   )
   .parse(process.argv);

--- a/src/lib/feature-finder.js
+++ b/src/lib/feature-finder.js
@@ -1,9 +1,9 @@
-import path from 'path'
-import fs from 'fs-extra'
-import Promise from 'bluebird'
-import Gherkin from 'gherkin'
-import glob from 'glob'
-import _ from 'lodash'
+import path from 'path';
+import fs from 'fs-extra';
+import Promise from 'bluebird';
+import Gherkin from 'gherkin';
+import glob from 'glob';
+import _ from 'lodash';
 
 let promiseGlob = Promise.promisify(glob);
 let gherkinParser = new Gherkin.Parser();

--- a/src/lib/parsers/pretty.js
+++ b/src/lib/parsers/pretty.js
@@ -1,11 +1,11 @@
-import path from 'path'
-import util from 'util'
-import fs from 'fs-extra'
-import prettyMs from 'pretty-ms'
-import _ from 'lodash'
-import Gherkin from 'gherkin'
-import colorMap from '../../../data/cucumber-color-map'
-import {colorize, indent, buffer} from '../../utils/unix'
+import path from 'path';
+import util from 'util';
+import fs from 'fs-extra';
+import prettyMs from 'pretty-ms';
+import _ from 'lodash';
+import Gherkin from 'gherkin';
+import colorMap from '../../../data/cucumber-color-map';
+import {colorize, indent, buffer} from '../../utils/unix';
 
 const gherkinParser = new Gherkin.Parser();
 
@@ -25,19 +25,19 @@ export default class PrettyParser {
     this.endTime;
   }
 
-  handleMessage(payload) {
+  handleResult(payload) {
     this.totalDuration += payload.duration;
     if (payload.exitCode !== 10) {
-      return this.parseMessage(payload.resultFile);
+      return this.parseResult(payload.resultFile);
     } else {
       return this.parseException(payload.featureFile, payload.scenarioLine, payload.exception);
     }
   }
 
-  parseMessage(resultsFile) {
+  parseResult(resultsFile) {
     let logFileJSON = fs.readJsonSync(resultsFile);
     let feature = logFileJSON.pop();
-    let featureFile = path.basename(feature.uri)
+    let featureFile = path.basename(feature.uri);
     let scenario = _.filter(feature.elements, ['type', 'scenario']).pop();
     let tagsArray = _.map(scenario.tags, 'name');
 

--- a/src/lib/sigint-handler.js
+++ b/src/lib/sigint-handler.js
@@ -1,4 +1,4 @@
-import readline from 'readline'
+import readline from 'readline';
 
 export default function(handler) {
   if (process.platform === "win32") {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'path';
 
 const testOptions = JSON.parse(process.env.testOptions);
 const cucumber = require(testOptions.cucumberPath).Cli;
@@ -24,6 +24,7 @@ try {
   cucumber(args).run(function(isSuccessful) {
     let exitCode = (isSuccessful) ? 0 : 1;
     process.send({
+      type: 'result',
       exitCode: exitCode,
       resultFile: logFile,
       duration: new Date() - startTime
@@ -31,6 +32,7 @@ try {
   });
 } catch (e) {
   process.send({
+    type: 'result',
     exitCode: 10,
     exception: e.stack,
     featureFile: featureFile,

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
-import fs from 'fs-extra'
-import _ from 'lodash'
-import Promise from 'bluebird'
-import TestHandler from './lib/test-handler'
-import sigintHandler from './lib/sigint-handler'
+import fs from 'fs-extra';
+import _ from 'lodash';
+import Promise from 'bluebird';
+import TestHandler from './lib/test-handler';
+import sigintHandler from './lib/sigint-handler';
 
 // Run if invoked from command line with CLI args
 if (!module.parent) {
@@ -18,9 +18,10 @@ if (!module.parent) {
 }
 
 // Run if invoked from being required by another modules with passed args
-module.exports = function(options) {
+export default function(options) {
   return run(options || {});
 };
+
 
 function run(options) {
   _.defaults(options, {

--- a/src/utils/unix.js
+++ b/src/utils/unix.js
@@ -28,4 +28,4 @@ export const buffer = {
     this.data = '';
     return bufferedData;
   }
-}
+};

--- a/src/utils/verbose-logger.js
+++ b/src/utils/verbose-logger.js
@@ -9,7 +9,7 @@ export default class VerboseLogger {
     }
 
     if (typeof output === 'object') {
-      output = JSON.stringify(output, null, 2)
+      output = JSON.stringify(output, null, 2);
     }
 
     let timestamp = new Date().toISOString();

--- a/src/utils/worker-log-handler.js
+++ b/src/utils/worker-log-handler.js
@@ -1,0 +1,19 @@
+/*
+This file must not include ES6 in order to support versions of node that do not include import, export,
+or other ES6 functions as it intended to be required in any given cucumber world.
+*/
+
+var util = require('util');
+
+module.exports = function() {
+  var output = util.format.apply(util, arguments);
+
+  if (!process.send) {
+    console.log(output);
+  } else {
+    process.send({
+      type: 'result',
+      message: output
+    });
+  }
+};

--- a/test/feature-finder-spec.js
+++ b/test/feature-finder-spec.js
@@ -1,12 +1,12 @@
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 chai.use(chaiAsPromised);
 chai.should();
 
-import featureFinder from '../src/lib/feature-finder'
-import options from './fixtures/options'
-import results from './results/feature-finder'
+import featureFinder from '../src/lib/feature-finder';
+import options from './fixtures/options';
+import results from './results/feature-finder';
 
 describe('Feature Finder', function(){
   it('should find all scenarios with default options', function () {

--- a/test/fixtures/logger-process.js
+++ b/test/fixtures/logger-process.js
@@ -1,0 +1,2 @@
+var logger = require('../../src/utils/worker-log-handler');
+logger('Test Command');

--- a/test/pretty-parser-spec.js
+++ b/test/pretty-parser-spec.js
@@ -11,11 +11,11 @@ const featureOutput = path.join(__dirname, 'fixtures', 'sample-feature-output.js
 describe('Pretty parser', function() {
   it('parser should handle a valid test run and update the tracked properties', function() {
     let parser = new PrettyParser({ silentSummary: true });
-    let output = parser.handleMessage({
+    let output = parser.handleResult({
       exitCode: 0,
       duration: 100,
       resultFile: featureOutput
-    })
+    });
 
     return Promise.all([
       parser.should.have.deep.property('totalSteps').and.to.be.equal(2),
@@ -32,7 +32,7 @@ describe('Pretty parser', function() {
   it('parser should handle a test that ended in an exception', function() {
     let parser = new PrettyParser({ silentSummary: true });
     let err = new Error('Test error');
-    let output = parser.handleMessage({
+    let output = parser.handleResult({
       exitCode: 10,
       duration: 100,
       featureFile: featureFile,
@@ -52,16 +52,16 @@ describe('Pretty parser', function() {
 
   it('parser should aggregate data when additional tests finish', function() {
     let parser = new PrettyParser({ silentSummary: true });
-    parser.handleMessage({
+    parser.handleResult({
       exitCode: 0,
       duration: 100,
       resultFile: featureOutput
-    })
-    parser.handleMessage({
+    });
+    parser.handleResult({
       exitCode: 0,
       duration: 200,
       resultFile: featureOutput
-    })
+    });
 
     return Promise.all([
       parser.should.have.deep.property('totalSteps').and.to.be.equal(4),
@@ -75,7 +75,7 @@ describe('Pretty parser', function() {
 
   it('parser should return summary log', function() {
     let parser = new PrettyParser({ silentSummary: true });
-    parser.handleMessage({
+    parser.handleResult({
       exitCode: 0,
       duration: 100,
       resultFile: featureOutput

--- a/test/test-handler-spec.js
+++ b/test/test-handler-spec.js
@@ -1,12 +1,12 @@
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-import fs from 'fs-extra'
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import fs from 'fs-extra';
 
 chai.use(chaiAsPromised);
 chai.should();
 
-import TestHandler from '../src/lib/test-handler'
-import options from './fixtures/options'
+import TestHandler from '../src/lib/test-handler';
+import options from './fixtures/options';
 
 describe('Test Handler', function() {
   it('should wait for all children to exit before returning', function () {
@@ -17,7 +17,7 @@ describe('Test Handler', function() {
 
     return cukeRunner.run().then(() => {
       return cukeRunner.workers.should.be.empty;
-    })
+    });
   });
 
   it('should return the overall exit code when all tests finish', function () {
@@ -26,13 +26,13 @@ describe('Test Handler', function() {
 
     function nonInjectedExitCode() {
       let cukeRunner = new TestHandler(opts);
-      return cukeRunner.run()
+      return cukeRunner.run();
     }
 
     function injectedExitCode() {
       let injectedCukeRunner = new TestHandler(opts);
       injectedCukeRunner.overallExitCode = 10;
-      return injectedCukeRunner.run()
+      return injectedCukeRunner.run();
     }
 
     return Promise.all([

--- a/test/verbose-logger-spec.js
+++ b/test/verbose-logger-spec.js
@@ -1,31 +1,42 @@
-import chai from 'chai'
-import sinon from 'sinon'
-import sinonChai from 'sinon-chai'
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
 chai.should();
 chai.use(sinonChai);
-sinon.spy(console, 'log');
 
-import VerboseLogger from '../src/utils/verbose-logger'
+import VerboseLogger from '../src/utils/verbose-logger';
 
 describe('Verbose Logger', function(){
   it('should output when verbose setting passed', function () {
+    let logSpy = sinon.spy(console, 'log');
     let verboseLog = new VerboseLogger(true);
+
     verboseLog.log('Test log');
     (console.log).should.have.been.called;
+
+    logSpy.restore();
   });
 
   it('should output when verbose setting passed with logScenarios', function () {
+    let logSpy = sinon.spy(console, 'log');
     let verboseLog = new VerboseLogger(true);
+
     verboseLog.logScenarios([
       {featureFile: 'test.feature', scenarioLine: 1}
     ]);
     (console.log).should.have.been.called;
+
+    logSpy.restore();
   });
 
   it('should not output when verbose setting is not passed', function () {
+    let logSpy = sinon.spy(console, 'log');
     let verboseLog = new VerboseLogger(false);
-    let returnedVal = verboseLog.log('Test log');
-    returnedVal.should.be.false;
+
+    verboseLog.log('Test log');
+    (console.log).should.not.have.been.called;
+
+    logSpy.restore();
   });
 });

--- a/test/worker-log-handler-spec.js
+++ b/test/worker-log-handler-spec.js
@@ -1,0 +1,32 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {fork} from 'child_process';
+
+chai.should();
+chai.use(sinonChai);
+
+import logger from '../src/utils/worker-log-handler';
+
+describe('Worker Log Handler', function(){
+  it('should print to console when not within a child process', function () {
+    let logSpy = sinon.spy(console, 'log');
+
+    logger('Test log');
+    (console.log).should.have.been.called;
+
+    logSpy.restore();
+  });
+
+  it('should return data when in a child process', function () {
+    return new Promise((resolve) => {
+      var worker = fork('./test/fixtures/logger-process.js', [], {
+        silent: true
+      });
+
+      worker.on('message', (payload) => {
+        resolve(payload.should.have.deep.property('message').and.to.be.equal('Test Command'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
This has a significant amount of files changed due to adding a missed linting rule that I apparently abused. 

This important pieces mostly revolve around messages form child processes having a `type` property, either "log" or "result", and handling them accordingly (https://github.com/midniteio/multi-cuke/compare/agnostic-log?expand=1#diff-eaff106c200e864c5c8afff31620f472R90).

This purpose to this PR is to satisfy https://github.com/midniteio/multi-cuke/issues/9, where `silent: true` on the forked processes means console.log will not display when running in parallel. This sets up the ability to batch logs from tests, and adds a utility in `src/lib/utils/worker-log-handler.js` to allow a variable defined in cucumber's world to act as a logger that would work whether in silenced child process or not. See documentation updates in this PR for more details.
