### PR TITLE
Remove readline createInterface hackery

### DIFF
--- a/src/lib/sigint-handler.js
+++ b/src/lib/sigint-handler.js
@@ -1,28 +1,15 @@
 import readline from 'readline';
 
 export default function(handler) {
-  if (process.platform === "win32") {
-    readline.createInterface({
-      input: process.stdin,
-      output: process.stdout
-    })
-    .on("SIGINT", function () {
-      process.emit("SIGINT");
-    });
-  }
-
-  process.on("SIGINT", function () {
-    handler.kill();
+  process.on('SIGINT', () => {
     process.exit();
   });
 
-  process.on('exit', function() {
-    handler.kill();
+  process.on('SIGTERM', () => {
+    process.exit();
   });
 
-  process.on('uncaughtException', function(e) {
-    console.error('Unhandled exception, terminating all worker processes...');
-    console.error(e.stack);
+  process.on('exit', () => {
     handler.kill();
   });
 }

--- a/src/lib/sigint-handler.js
+++ b/src/lib/sigint-handler.js
@@ -1,5 +1,3 @@
-import readline from 'readline';
-
 export default function(handler) {
   process.on('SIGINT', () => {
     process.exit();


### PR DESCRIPTION
This stuff doesn't seem to be necessary and prevents node from shutting down as it creates an extra reference to stdin in node's active handles.
