### PR TITLE
shell out to cucumber-js

### DIFF
--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -113,10 +113,10 @@ export default class TestHandler {
     this.workers.push(worker);
 
     return worker.execute()
-      .then(function(result) {
+      .then((result) => {
         return done(result);
       })
-      .catch(function(err) {
+      .catch((err) => {
         console.log(err.stack);
       });
   }

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -114,13 +114,17 @@ export default class TestHandler {
       }
     }.bind(this);
 
-    worker.execute(done);
-
     worker.debugLogArray = [];
     worker.scenario = scenario;
     this.workers.push(worker);
 
-    return worker;
+    return worker.execute()
+    .then(function(result) {
+      return done(result);
+    })
+    .catch(function(err) {
+      console.error(err.stack);
+    });
   }
 
   kill() {

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -1,5 +1,4 @@
 import {cpus} from 'os';
-import {fork} from 'child_process';
 import path from 'path';
 import _ from 'lodash';
 import Promise from 'bluebird';

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -79,7 +79,8 @@ export default class TestHandler {
       scenarioLine: scenario.scenarioLine,
       logDir: this.options.logDir,
       cucumberPath: path.resolve(cucumberPath),
-      requires: this.options.requires
+      requires: this.options.requires,
+      scenario: scenario
     };
 
     let worker = new Worker(testOptions);
@@ -114,8 +115,6 @@ export default class TestHandler {
       }
     }.bind(this);
 
-    worker.debugLogArray = [];
-    worker.scenario = scenario;
     this.workers.push(worker);
 
     return worker.execute()
@@ -123,7 +122,14 @@ export default class TestHandler {
       return done(result);
     })
     .catch(function(err) {
-      console.error(err.stack);
+      return done({
+        type: 'result',
+        exitCode: 10,
+        exception: err,
+        featureFile: scenario.featureFile,
+        scenarioLine: scenario.scenarioLine,
+        duration: 0
+      });
     });
   }
 

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -69,10 +69,7 @@ export default class TestHandler {
   createWorker(scenario) {
     this.verboseLogger.log('Initializing worker for: ' + scenario.featureFile + ':' + scenario.scenarioLine);
 
-    let cucumberPath = './node_modules/.bin/cucumber-js';
-    if (process.platform === 'win32') {
-      cucumberPath += '.cmd';
-    }
+    let cucumberPath = './node_modules/cucumber/bin/cucumber.js';
 
     let testOptions = {
       featureFile: scenario.featureFile,

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -77,7 +77,8 @@ export default class TestHandler {
       logDir: this.options.logDir,
       cucumberPath: path.resolve(cucumberPath),
       requires: this.options.requires,
-      scenario: scenario
+      scenario: scenario,
+      inlineStream: this.options.inlineStream
     };
 
     let worker = new Worker(testOptions);
@@ -85,7 +86,6 @@ export default class TestHandler {
     let done = function(payload) {
       let output = this.outputHandler.handleResult(payload);
       console.log(output);
-      console.log(worker.debugLogArray.join('\n'));
 
       if (payload.exitCode !== 0) {
         this.overallExitCode = 1;

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -63,7 +63,7 @@ export default class Worker {
   }
 
   kill() {
-    if (this.child && this.child.connected) {
+    if (this.child) {
       this.child.kill();
     }
   }

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -18,18 +18,21 @@ export default class Worker {
       this.args.push('-r');
       this.args.push(arg);
     });
-    this.debugLogArray = [];
+    if (options.inlineStream) {
+      this.ioMode = 'inherit';
+    } else {
+      this.ioMode = 'ignore';
+    }
   }
 
   execute() {
     return new Promise(function(resolve) {
       let startTime = new Date();
 
-      // TODO: allow inheriting stdio
       this.child = spawn(
         process.execPath,
         this.args,
-        {stdio: 'ignore'}
+        {stdio: this.ioMode}
       );
 
       this.child.on('exit', function(code) {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -5,55 +5,53 @@ import Promise from 'bluebird';
 export default class Worker {
   constructor(options) {
     this.options = options;
+    this.featureFile = this.options.featureFile;
+    this.featureFileData = path.parse(this.featureFile);
+    this.featureName = this.featureFileData.name;
+    this.scenarioLine = this.options.scenarioLine;
+    this.logFileName = this.featureName + '-line-' + this.scenarioLine + '.json';
+    this.logFile = path.join(this.options.logDir, this.logFileName);
+    this.relativeLogFile = path.relative(process.cwd(), this.logFile);
+    this.cucumberPath = this.options.cucumberPath;
+    this.args = [this.featureFile + ':' + this.scenarioLine, '-f', 'json:' + this.relativeLogFile];
+    this.options.requires.forEach(function(arg) {
+      this.args.push('-r');
+      this.args.push(arg);
+    });
   }
 
   execute() {
     return new Promise(function(resolve) {
-      let featureFile = this.options.featureFile;
-      let featureFileData = path.parse(featureFile);
-      let featureName = featureFileData.name;
-      let scenarioLine = this.options.scenarioLine;
-      let logFileName = featureName + '-line-' + scenarioLine + '.json';
-      let logFile = path.join(this.options.logDir, logFileName);
-      let relativeLogFile = relativeLogFile = path.relative(process.cwd(), logFile);
-      let cucumberPath = this.options.cucumberPath;
-      let args = [featureFile + ':' + scenarioLine, '-f', 'json:' + relativeLogFile];
-
-      this.options.requires.forEach(function(arg) {
-        args.push('-r');
-        args.push(arg);
-      });
+      let startTime = new Date();
 
       // TODO: allow inheriting stdio
       this.child = spawn(
-        cucumberPath,
-        args,
+        this.cucumberPath,
+        this.args,
         {stdio: 'ignore'}
       );
-
-      let startTime = new Date();
 
       this.child.on('exit', function(code) {
         resolve({
           type: 'result',
           exitCode: code,
-          featureFile: featureFile,
-          scenarioLine: scenarioLine,
-          resultFile: logFile,
+          featureFile: this.featureFile,
+          scenarioLine: this.scenarioLine,
+          resultFile: this.logFile,
           duration: new Date() - startTime
         });
-      });
+      }.bind(this));
 
       this.child.on('error', function(err) {
         resolve({
           type: 'result',
           exitCode: 10,
           exception: err,
-          featureFile: featureFile,
-          scenarioLine: scenarioLine,
+          featureFile: this.featureFile,
+          scenarioLine: this.scenarioLine,
           duration: new Date() - startTime
         });
-      });
+      }.bind(this));
     }.bind(this));
   }
 

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -47,19 +47,6 @@ export default class Worker {
       }
     });
 
-    this.child.on('close', function(code) {
-      if (running) {
-        running = false;
-        callback({
-          type: 'result',
-          exitCode: code,
-          featureFile: featureFile,
-          scenarioLine: scenarioLine,
-          duration: new Date() - startTime
-        });
-      }
-    });
-
     this.child.on('error', function(err) {
       if (running) {
         running = false;

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -13,7 +13,7 @@ export default class Worker {
     this.logFile = path.join(options.logDir, this.logFileName);
     this.relativeLogFile = path.relative(process.cwd(), this.logFile);
     this.cucumberPath = options.cucumberPath;
-    this.args = [this.featureFile + ':' + this.scenarioLine, '-f', 'json:' + this.relativeLogFile];
+    this.args = [this.cucumberPath, this.featureFile + ':' + this.scenarioLine, '-f', 'json:' + this.relativeLogFile];
     options.requires.forEach(function(arg) {
       this.args.push('-r');
       this.args.push(arg);
@@ -27,7 +27,7 @@ export default class Worker {
 
       // TODO: allow inheriting stdio
       this.child = spawn(
-        this.cucumberPath,
+        process.execPath,
         this.args,
         {stdio: 'ignore'}
       );

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -4,20 +4,21 @@ import Promise from 'bluebird';
 
 export default class Worker {
   constructor(options) {
-    this.options = options;
-    this.featureFile = this.options.featureFile;
+    this.scenario = options.scenario;
+    this.featureFile = options.featureFile;
     this.featureFileData = path.parse(this.featureFile);
     this.featureName = this.featureFileData.name;
-    this.scenarioLine = this.options.scenarioLine;
+    this.scenarioLine = options.scenarioLine;
     this.logFileName = this.featureName + '-line-' + this.scenarioLine + '.json';
-    this.logFile = path.join(this.options.logDir, this.logFileName);
+    this.logFile = path.join(options.logDir, this.logFileName);
     this.relativeLogFile = path.relative(process.cwd(), this.logFile);
-    this.cucumberPath = this.options.cucumberPath;
+    this.cucumberPath = options.cucumberPath;
     this.args = [this.featureFile + ':' + this.scenarioLine, '-f', 'json:' + this.relativeLogFile];
-    this.options.requires.forEach(function(arg) {
+    options.requires.forEach(function(arg) {
       this.args.push('-r');
       this.args.push(arg);
     });
+    this.debugLogArray = [];
   }
 
   execute() {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -1,42 +1,40 @@
 import path from 'path';
 import {spawn} from 'child_process';
+import Promise from 'bluebird';
 
 export default class Worker {
   constructor(options) {
     this.options = options;
   }
 
-  execute(callback) {
-    let featureFile = this.options.featureFile;
-    let featureFileData = path.parse(featureFile);
-    let featureName = featureFileData.name;
-    let scenarioLine = this.options.scenarioLine;
-    let logFileName = featureName + '-line-' + scenarioLine + '.json';
-    let logFile = path.join(this.options.logDir, logFileName);
-    let relativeLogFile = relativeLogFile = path.relative(process.cwd(), logFile);
-    let cucumberPath = this.options.cucumberPath;
-    let args = [featureFile + ':' + scenarioLine, '-f', 'json:' + relativeLogFile];
-    let running = false;
+  execute() {
+    return new Promise(function(resolve) {
+      let featureFile = this.options.featureFile;
+      let featureFileData = path.parse(featureFile);
+      let featureName = featureFileData.name;
+      let scenarioLine = this.options.scenarioLine;
+      let logFileName = featureName + '-line-' + scenarioLine + '.json';
+      let logFile = path.join(this.options.logDir, logFileName);
+      let relativeLogFile = relativeLogFile = path.relative(process.cwd(), logFile);
+      let cucumberPath = this.options.cucumberPath;
+      let args = [featureFile + ':' + scenarioLine, '-f', 'json:' + relativeLogFile];
 
-    this.options.requires.forEach(function(arg) {
-      args.push('-r');
-      args.push(arg);
-    });
+      this.options.requires.forEach(function(arg) {
+        args.push('-r');
+        args.push(arg);
+      });
 
-    // TODO: allow inheriting stdio
-    this.child = spawn(
-      cucumberPath,
-      args,
-      {stdio: 'ignore'}
-    );
-    running = true;
+      // TODO: allow inheriting stdio
+      this.child = spawn(
+        cucumberPath,
+        args,
+        {stdio: 'ignore'}
+      );
 
-    let startTime = new Date();
+      let startTime = new Date();
 
-    this.child.on('exit', function(code) {
-      if (running) {
-        running = false;
-        callback({
+      this.child.on('exit', function(code) {
+        resolve({
           type: 'result',
           exitCode: code,
           featureFile: featureFile,
@@ -44,13 +42,10 @@ export default class Worker {
           resultFile: logFile,
           duration: new Date() - startTime
         });
-      }
-    });
+      });
 
-    this.child.on('error', function(err) {
-      if (running) {
-        running = false;
-        callback({
+      this.child.on('error', function(err) {
+        resolve({
           type: 'result',
           exitCode: 10,
           exception: err,
@@ -58,8 +53,8 @@ export default class Worker {
           scenarioLine: scenarioLine,
           duration: new Date() - startTime
         });
-      }
-    });
+      });
+    }.bind(this));
   }
 
   kill() {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -14,10 +14,10 @@ export default class Worker {
     this.relativeLogFile = path.relative(process.cwd(), this.logFile);
     this.cucumberPath = options.cucumberPath;
     this.args = [this.cucumberPath, this.featureFile + ':' + this.scenarioLine, '-f', 'json:' + this.relativeLogFile];
-    options.requires.forEach(function(arg) {
+    options.requires.forEach((arg) => {
       this.args.push('-r');
       this.args.push(arg);
-    }.bind(this));
+    });
     if (options.inlineStream) {
       this.ioMode = 'inherit';
     } else {
@@ -26,7 +26,7 @@ export default class Worker {
   }
 
   execute() {
-    return new Promise(function(resolve) {
+    return new Promise((resolve) => {
       let startTime = new Date();
 
       this.child = spawn(
@@ -35,7 +35,7 @@ export default class Worker {
         {stdio: this.ioMode}
       );
 
-      this.child.on('exit', function(code) {
+      this.child.on('exit', (code) => {
         resolve({
           type: 'result',
           exitCode: code,
@@ -44,9 +44,9 @@ export default class Worker {
           resultFile: this.logFile,
           duration: new Date() - startTime
         });
-      }.bind(this));
+      });
 
-      this.child.on('error', function(err) {
+      this.child.on('error', (err) => {
         resolve({
           type: 'result',
           exitCode: 10,
@@ -55,8 +55,8 @@ export default class Worker {
           scenarioLine: this.scenarioLine,
           duration: new Date() - startTime
         });
-      }.bind(this));
-    }.bind(this));
+      });
+    });
   }
 
   kill() {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -17,7 +17,7 @@ export default class Worker {
     options.requires.forEach(function(arg) {
       this.args.push('-r');
       this.args.push(arg);
-    });
+    }.bind(this));
     if (options.inlineStream) {
       this.ioMode = 'inherit';
     } else {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -1,6 +1,5 @@
 import path from 'path';
 import {spawn} from 'child_process';
-import fs from 'fs';
 
 export default class Worker {
   constructor(options) {

--- a/test/test-handler-spec.js
+++ b/test/test-handler-spec.js
@@ -11,6 +11,7 @@ import options from './fixtures/options';
 describe('Test Handler', function() {
   it('should wait for all children to exit before returning', function () {
     var opts = options.default;
+    this.timeout(5000);
     fs.ensureDir(opts.logDir);
 
     let cukeRunner = new TestHandler(opts);
@@ -22,6 +23,7 @@ describe('Test Handler', function() {
 
   it('should return the overall exit code when all tests finish', function () {
     var opts = options.default;
+    this.timeout(5000);
     fs.ensureDir(opts.logDir);
 
     function nonInjectedExitCode() {
@@ -43,6 +45,7 @@ describe('Test Handler', function() {
 
   it('should return the output handler', function () {
     var opts = options.default;
+    this.timeout(5000);
     fs.ensureDir(opts.logDir);
 
     let cukeRunner = new TestHandler(opts);
@@ -53,6 +56,7 @@ describe('Test Handler', function() {
 
   it('should have the summary available from the ouput handler ', function () {
     var opts = options.default;
+    this.timeout(5000);
     fs.ensureDir(opts.logDir);
 
     let cukeRunner = new TestHandler(opts);


### PR DESCRIPTION
@midniteio @efokschaner @vsiakka 

This replaces the current fork + cucumber-js API approach with directly spawning a new process that shells out to cucumber-js. This way, if cucumber-js ends for any reason (crash, regular test failure, etc.) we'll still detect the process has exited and handle it properly.
