### PR TITLE
Fix args passed to devmode so that it can accept multiple paths

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -40,7 +40,7 @@ function run(options) {
 
   if (options.devMode) {
     let cucumber = require(options.cucumberPath).Cli;
-    let args = ['', '', options.paths.join(' ')];
+    let args = _.concat(['', ''], options.paths);
     options.tags.forEach(function(arg) {
       args.push('-t');
       args.push(arg);


### PR DESCRIPTION
This previously was incorrect and would pass all paths as one argument, however we hadn't caught it because the general usecase isn't to use multiple paths anyway
