### PR TITLE
Grab error message from stderr, pass to parser

### DIFF
--- a/src/lib/parsers/pretty.js
+++ b/src/lib/parsers/pretty.js
@@ -90,6 +90,7 @@ export default class PrettyParser {
   }
 
   parseException(feature, scenario, exception) {
+    let errorMessage = exception.stack || exception;
     buffer.log('Feature: ' + feature.name);
 
     if (scenario.tags) {
@@ -98,7 +99,7 @@ export default class PrettyParser {
     }
 
     buffer.log(indent(1) + 'Scenario: ' + scenario.name);
-    buffer.log(colorize(indent(1) + exception, 'red'));
+    buffer.log(colorize(indent(1) + errorMessage, 'red'));
 
     this.failedScenarios.push(path.basename(feature.uri) + ':' + scenario.location.line + ' # ' + scenario.name);
     this.scenarioStatuses.failed++;

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -125,11 +125,6 @@ export default class TestHandler {
           console.log(this.outputHandler.getSummaryOutput());
         }
       }
-
-      if (payload.exception) {
-        console.log('Error caught: ', payload.exception);
-        console.log(payload.exception.stack);
-      }
     };
 
     this.workers.push(worker);


### PR DESCRIPTION
Previously, if cucumber failed for reasons such as a missing npm-dependency, it would return errors on 'Cucumber was unable to produce valid results'. This will return the actual stderr, so to include the messaging around that error rather than swallow it.
