### PR TITLE
Bumping gherkin version to 4.0.0 to get some gherkin crash fixes for …

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "commander": "^2.9.0",
     "cucumber": "^0.9.5",
     "fs-extra": "^0.26.5",
-    "gherkin": "^3.2.0",
+    "gherkin": "^4.0.0",
     "glob": "^7.0.0",
     "lodash": "^4.5.0",
     "pretty-ms": "^2.1.0"

--- a/src/lib/feature-finder.js
+++ b/src/lib/feature-finder.js
@@ -20,9 +20,9 @@ export default function(cucumberOptions) {
     files = _.flattenDeep(files);
     return files.map((file) => {
       let featureData = parseFeature(file);
-      return featureData.scenarioDefinitions
-        .filter((scenario) => {
-          return verifyTags(scenario, cucumberOptions.tags);
+      return featureData.children
+        .filter((child) => {
+          return child.type === "Scenario" && verifyTags(child, cucumberOptions.tags);
         })
         .map((scenario) => {
           return {
@@ -40,10 +40,10 @@ export default function(cucumberOptions) {
 function parseFeature(featurePath) {
   try {
     let file = fs.readFileSync(featurePath, {encoding: 'utf8'});
-    return gherkinParser.parse(file);
+    return gherkinParser.parse(file).feature;
   } catch (e) {
     console.log(featurePath + ' could not be parsed from Gherkin, ignoring as a feature file.', e);
-    return {scenarioDefinitions: []};
+    return {children: []};
   }
 }
 

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -14,8 +14,8 @@ export default class Worker {
 
     let file = fs.readFileSync(this.featureFile, { encoding: 'utf8' });
 
-    this.featureData = gherkinParser.parse(file);
-    this.scenarioData = this.featureData.scenarioDefinitions.filter((scenario) => {
+    this.featureData = gherkinParser.parse(file).feature;
+    this.scenarioData = this.featureData.children.filter((scenario) => {
       return (scenario.location.line === parseInt(this.scenarioLine));
     }).pop();
 

--- a/test/pretty-parser-spec.js
+++ b/test/pretty-parser-spec.js
@@ -10,9 +10,9 @@ const featureFile = path.join(__dirname, 'features', 'sample.feature');
 const featureFileData = fs.readFileSync(featureFile, { encoding: 'utf8' });
 const featureOutput = require('./fixtures/sample-feature-output.json').pop();
 const gherkinParser = new Gherkin.Parser();
-const feature = gherkinParser.parse(featureFileData);
-const scenario = feature.scenarioDefinitions.filter((scenario) => {
-  return (scenario.location.line === 7);
+const feature = gherkinParser.parse(featureFileData).feature;
+const scenario = feature.children.filter((child) => {
+  return (child.location.line === 7);
 }).pop();
 
 describe('Pretty parser', function() {
@@ -25,7 +25,6 @@ describe('Pretty parser', function() {
       scenario: scenario,
       feature: feature
     });
-
     return Promise.all([
       parser.should.have.deep.property('totalSteps').and.to.be.equal(2),
       parser.should.have.deep.property('totalScenarios').and.to.be.equal(1),


### PR DESCRIPTION
…behaviors that cucumber already supported

I am specifically interested in grabbing these fixes: 
- (All) Allow emtpy Feature files
- (All) Allow incomplete scenario outlines 

From: https://github.com/cucumber/gherkin/blob/master/CHANGELOG.md#changed-1

Don't merge yet though, cause I need to test these changes with tests with backgrounds.
