### PR TITLE
more gracefully handle undefined exceptions

### DIFF
--- a/src/lib/parsers/pretty.js
+++ b/src/lib/parsers/pretty.js
@@ -92,7 +92,7 @@ export default class PrettyParser {
   parseException(feature, scenario, exception) {
     let errorMessage = 'Unknown error';
     if (exception) {
-      exception.stack || exception;
+      errorMessage = exception.stack || exception;
     }
     let featureUri = feature.uri || '';
     buffer.log('Feature: ' + feature.name);

--- a/src/lib/parsers/pretty.js
+++ b/src/lib/parsers/pretty.js
@@ -90,7 +90,10 @@ export default class PrettyParser {
   }
 
   parseException(feature, scenario, exception) {
-    let errorMessage = exception.stack || exception;
+    let errorMessage = 'Unknown error';
+    if (exception) {
+      exception.stack || exception;
+    }
     let featureUri = feature.uri || '';
     buffer.log('Feature: ' + feature.name);
 


### PR DESCRIPTION
fixes #44

There's probably some deeper issue here, exception should never be undefined. However, this at least fails more nicely.
