### PR TITLE
Make sure multi-cuke raises a non 0 exit code when we can't parse the output of a scenario

### DIFF
--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -54,6 +54,7 @@ export default class Worker {
       } catch (e) {
         e.msg = 'Cucumber has failed to produce parseable results.' + e.msg;
         err = err || e;
+        exitCode = 1;
       }
     }
 


### PR DESCRIPTION
When we fail to parse the output of a scenario, the pretty formatter logs an error for the scenario, but we don't log any other information (eg failed steps).  We also propagate the exit code that cucumber gave us. 

With this change I am suggesting that if we fail to parse the output, we should exit with a non-0 code, regardless of the cucumber exit code. This way we can at least be informed of the failure and then investigate why the hell is the log not parsable (is it because of cucumber or something we did in a step).

Opinions? @guykisel @midniteio @efokschaner 
