### PR TITLE
When there is a parsing error we should exit with a non 0 exit code

### DIFF
--- a/src/lib/feature-finder.js
+++ b/src/lib/feature-finder.js
@@ -62,7 +62,7 @@ function parseFeature(featurePath) {
     let file = fs.readFileSync(featurePath, {encoding: 'utf8'});
     return gherkinParser.parse(file).feature;
   } catch (e) {
-    console.error(featurePath + ' could not be parsed from Gherkin, ignoring as a feature file.\n', e.message);
+    console.error(featurePath + ' could not be parsed from Gherkin, ignoring as a feature file.', e.message);
     return {children: [], didDetectErrors: true};
   }
 }

--- a/src/lib/feature-finder.js
+++ b/src/lib/feature-finder.js
@@ -30,7 +30,6 @@ export default function(cucumberOptions) {
         .map((scenario) => {
 /*eslint-disable max-nested-callbacks*/
           if (scenario.type === 'ScenarioOutline') {
-
             return scenario.examples.map((example) => {
               return example.tableBody.filter(tableBody => tableBody.type === 'TableRow')
               .map((row) => {

--- a/src/lib/feature-finder.js
+++ b/src/lib/feature-finder.js
@@ -53,7 +53,7 @@ export default function(cucumberOptions) {
     });
   })
   .then((results) => {
-    return {scenarios:_.flattenDeep(results), didDetectErrors: didDetectErrors};
+    return {scenarios:_.flattenDeep(results), didDetectErrors};
   });
 };
 

--- a/src/lib/feature-finder.js
+++ b/src/lib/feature-finder.js
@@ -9,6 +9,7 @@ let promiseGlob = Promise.promisify(glob);
 let gherkinParser = new Gherkin.Parser();
 
 export default function(cucumberOptions) {
+  let didDetectErrors = false;
   return Promise.map(cucumberOptions.paths, (featurePath) => {
     if (path.parse(featurePath).ext) {
       return Promise.resolve(featurePath);
@@ -19,8 +20,9 @@ export default function(cucumberOptions) {
   .then((files) => {
     files = _.flattenDeep(files);
     return files.map((file) => {
-      let featureData = parseFeature(file);
-      return featureData.children
+      let parsedData = parseFeature(file);
+      didDetectErrors = parsedData.didDetectErrors ? true : didDetectErrors;
+      return parsedData.children
         .filter((child) => {
           return (child.type === 'Scenario' || child.type === 'ScenarioOutline')
                  && verifyTags(child, cucumberOptions.tags);
@@ -28,6 +30,7 @@ export default function(cucumberOptions) {
         .map((scenario) => {
 /*eslint-disable max-nested-callbacks*/
           if (scenario.type === 'ScenarioOutline') {
+
             return scenario.examples.map((example) => {
               return example.tableBody.filter(tableBody => tableBody.type === 'TableRow')
               .map((row) => {
@@ -50,7 +53,7 @@ export default function(cucumberOptions) {
     });
   })
   .then((results) => {
-    return _.flattenDeep(results);
+    return {scenarios:_.flattenDeep(results), didDetectErrors: didDetectErrors};
   });
 };
 
@@ -59,8 +62,8 @@ function parseFeature(featurePath) {
     let file = fs.readFileSync(featurePath, {encoding: 'utf8'});
     return gherkinParser.parse(file).feature;
   } catch (e) {
-    console.log(featurePath + ' could not be parsed from Gherkin, ignoring as a feature file.', e);
-    return {children: []};
+    console.error(featurePath + ' could not be parsed from Gherkin, ignoring as a feature file.\n', e.message);
+    return {children: [], didDetectErrors: true};
   }
 }
 

--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -38,12 +38,18 @@ export default class TestHandler {
   }
 
   runTestSuite() {
-    return featureFinder(this.options).then((scenarios) => {
-      this.verboseLogger.log('Scenarios found that match options:');
-      this.verboseLogger.logScenarios(scenarios);
+    return featureFinder(this.options).then((result) => {
+      if (result.didDetectErrors) {
+        this.overallExitCode = 1;
+      }
 
+      let scenarios = result.scenarios;
       if (_.isEmpty(scenarios)) {
         console.log('There are no scenarios found that match the options passed: \n', this.options);
+        this.outputHandler.setEndTime();
+      } else {
+        this.verboseLogger.log('Scenarios found that match options:');
+        this.verboseLogger.logScenarios(scenarios);
       }
 
       this.scenarios = scenarios;

--- a/src/main.js
+++ b/src/main.js
@@ -11,7 +11,12 @@ if (!module.parent) {
 
   run(cliOptions).then((results) => {
     if (results.outputHandler) {
-      console.log(results.outputHandler.getSummaryOutput());
+      try {
+        console.log(results.outputHandler.getSummaryOutput());
+      } catch (e) {
+        console.error('Exception while printing results: ', e);
+        results.exitCode = 1;
+      }
     }
     process.exit(results.exitCode);
   });

--- a/test/results/feature-finder.js
+++ b/test/results/feature-finder.js
@@ -1,150 +1,174 @@
 import path from 'path';
 
 module.exports = {
-  default: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 11
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 14
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample2.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 4
-    },
-    {
-      featureFile: path.join('test','features','sample3.feature'),
-      isScenarioOutline: true,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test','features','sample3.feature'),
-      isScenarioOutline: true,
-      scenarioLine: 8
-    }
-  ],
-  tagged: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 11
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample2.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 4
-    }
-  ],
-  negatedTag: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 14
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample2.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 4
-    },
-    {
-      featureFile: path.join('test','features','sample3.feature'),
-      isScenarioOutline: true,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test','features','sample3.feature'),
-      isScenarioOutline: true,
-      scenarioLine: 8
-    }
-  ],
-  multipleTags: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    }
-  ],
-  mixedTags: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    }
-  ],
-  orOperatorTags: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 11
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample2.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 4
-    }
-  ],
-  featurePath: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 11
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 14
-    }
-  ],
-  multiplePaths: [
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 7
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 11
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 14
-    },
-    {
-      featureFile: path.join('test', 'features', 'sample2.feature'),
-      isScenarioOutline: false,
-      scenarioLine: 4
-    }
-  ]
+  default: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 11
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 14
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample2.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 4
+      },
+      {
+        featureFile: path.join('test','features','sample3.feature'),
+        isScenarioOutline: true,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test','features','sample3.feature'),
+        isScenarioOutline: true,
+        scenarioLine: 8
+      }
+    ],
+    didDetectErrors: false
+  },
+  tagged: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 11
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample2.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 4
+      }
+    ],
+    didDetectErrors: false
+  },
+  negatedTag: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 14
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample2.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 4
+      },
+      {
+        featureFile: path.join('test','features','sample3.feature'),
+        isScenarioOutline: true,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test','features','sample3.feature'),
+        isScenarioOutline: true,
+        scenarioLine: 8
+      }
+    ],
+    didDetectErrors: false
+  },
+  multipleTags: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      }
+    ],
+    didDetectErrors: false
+  },
+  mixedTags: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      }
+    ],
+    didDetectErrors: false
+  },
+  orOperatorTags: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 11
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample2.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 4
+      }
+    ],
+    didDetectErrors: false
+  },
+  featurePath: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 11
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 14
+      }
+    ],
+    didDetectErrors: false
+  },
+  multiplePaths: {
+    scenarios: [
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 7
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 11
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 14
+      },
+      {
+        featureFile: path.join('test', 'features', 'sample2.feature'),
+        isScenarioOutline: false,
+        scenarioLine: 4
+      }
+    ],
+    didDetectErrors: false
+  }
 };


### PR DESCRIPTION
- Make sure multi-cuke raises a non 0 exit code when we can't parse the a feature
- Make sure multi-cuke raises a non 0 exit code when the parser raises an exception
- Make feature parsing errors more readable

This also addresses https://github.com/midniteio/multi-cuke/issues/24
@midniteio @efokschaner @guykisel 
