### PR TITLE
Add outline data to the logs. Merge scenarios under features as Cucumber

### DIFF
--- a/src/lib/test-handler.js
+++ b/src/lib/test-handler.js
@@ -80,17 +80,23 @@ export default class TestHandler {
     logFilePaths.forEach((logFilePath) => {
       try {
         if (_.endsWith(logFilePath, '.json')) {
-          testResults = _.concat(
-            testResults,
-            fs.readJsonSync(path.join(this.options.logDir, logFilePath), 'utf8')
-          );
+          let log = fs.readJsonSync(path.join(this.options.logDir, logFilePath), 'utf8')[0];
+          let existingLog = _.find(testResults, testResult => {
+            return testResult.name === log.name && testResult.line === log.line;
+          });
+
+          if (existingLog) {
+            existingLog.elements.push(log.elements[0]);
+          } else {
+            testResults = _.concat(testResults, [log]);
+          }
         }
       } catch (e) {
         // ignore errors from invalid/empty files
       }
     });
     fs.ensureDirSync(path.join(this.options.logDir, 'merged'));
-    fs.writeFileSync(mergedFileName, JSON.stringify(testResults, null, 4));
+    fs.writeJsonSync(mergedFileName, testResults);
   }
 
   createWorker(scenario) {

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -3,6 +3,7 @@ import {spawn} from 'child_process';
 import fs from 'fs-extra';
 import Gherkin from 'gherkin';
 import Promise from 'bluebird';
+import _ from 'lodash';
 
 const gherkinParser = new Gherkin.Parser();
 
@@ -26,7 +27,9 @@ export default class Worker {
     })[0];
 
     this.exampleData = this.isScenarioOutline && this.scenarioData.examples.map(({ tableBody }) => {
-      return tableBody.find(({ cells }) => cells.find(cell => cell.location.line === parseInt(this.scenarioLine)));
+      return _.find(tableBody, ({ cells }) => {
+        return _.find(cells, cell => cell.location.line === parseInt(this.scenarioLine));
+      });
     })[0].cells[0];
 
     this.logFileName = path.basename(this.featureFile) + '-line-' + this.scenarioLine + '.json';

--- a/src/lib/worker.js
+++ b/src/lib/worker.js
@@ -16,16 +16,18 @@ export default class Worker {
     let file = fs.readFileSync(this.featureFile, { encoding: 'utf8' });
 
     this.featureData = gherkinParser.parse(file).feature;
-    this.scenarioData = this.featureData.children.filter((scenario) => {
+    this.scenarioData = this.featureData.children.filter(scenario => {
       if (this.isScenarioOutline) {
-        return scenario.type === 'ScenarioOutline' && scenario.examples.some((example) => {
-          return example.tableBody.some((row) => {
-            return row.location.line === parseInt(this.scenarioLine);
-          });
+        return scenario.type === 'ScenarioOutline' && scenario.examples.some(example => {
+          return example.tableBody.some(row => row.location.line === parseInt(this.scenarioLine));
         });
       }
       return (scenario.location.line === parseInt(this.scenarioLine));
-    }).pop();
+    })[0];
+
+    this.exampleData = this.isScenarioOutline && this.scenarioData.examples.map(({ tableBody }) => {
+      return tableBody.find(({ cells }) => cells.find(cell => cell.location.line === parseInt(this.scenarioLine)));
+    })[0].cells[0];
 
     this.logFileName = path.basename(this.featureFile) + '-line-' + this.scenarioLine + '.json';
     this.logFile = path.join(options.logDir, this.logFileName);
@@ -53,6 +55,13 @@ export default class Worker {
     let results = null;
     try {
       results = fs.readJsonSync(this.logFile).pop();
+
+      // Inject example data into the results json as it's not provided by cucumber's formatter
+      // A custom formatter could be written in Cucumber v2.0.0+, but is unsupported in ^1.0.0
+      if (this.isScenarioOutline) {
+        results.elements[0].exampleData = this.exampleData.value;
+        fs.writeJsonSync(this.logFile, [ results ]);
+      }
     } catch (e) {
       e.msg = 'Cucumber has failed to produce parseable results.' + e.msg;
       err = err || e;


### PR DESCRIPTION
For the ghost @atraintanski

*Note* This is to be considered a breaking change to the api, as the results file produced has changed its format slightly. It now aligns with how default Cucumber groups logs (Scenarios are grouped and nested with a feature, we currently dupe feature per scenario).

This also injects the value used from a scenario outline into the log data. Cucumberjs v2+ allows for custom formatters to address this, but I don't want to constrain versions so tightly.